### PR TITLE
Add some explainers, add episode art, unique ID, better descriptions

### DIFF
--- a/podcast.xml
+++ b/podcast.xml
@@ -33,10 +33,12 @@ layout: null
             <itunes:episodeType>{{ post.episodeType }}</itunes:episodeType>
             <itunes:explicit>{{ post.explicit }}</itunes:explicit>
             <link>{{ post.url | absolute_url }}</link>
+            <itunes:image href='{{ post.cover | default: site.podcast.logo | absolute_url }}'/>
             <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
             <itunes:duration>{{ post.length | xml_escape }}</itunes:duration>
+            <guid>{{ post.audio | absolute_url }}</guid>
             <enclosure url='{{ post.audio | absolute_url }}' length='{{ post.length | xml_escape }}'/>
-            <description>{{ post.content | xml_escape | strip_newlines }}</description>
+            <description><![CDATA[{{ post.content | cdata_escape }}]]></description>
         </item>
         {% endfor %}
     </channel>

--- a/sample/_config.yaml
+++ b/sample/_config.yaml
@@ -5,10 +5,10 @@ podcast:
   author: [podcast author]
   email: [podcast email]
   logo: [podcast logo url] # logo in 1400 – 3000 pixel
-  language: [language] # http://www.loc.gov/standards/iso639-2/php/code_list.php
+  language: [language] # http://www.loc.gov/standards/iso639-2/php/code_list.php (ie. 'en-us')
   category: [category] # https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12
   subcategory: [subcategory]
   type: [podcast type] # episodic | serial
-  explicit: [explicit state] # true | false
+  explicit: [explicit state] # true (must be true if at least one episode is explicit) | false
   complete: [complete state] # 'yes' | 'no'
-  block: [block state] # 'yes' | 'no'
+  block: [block state] # 'yes' (hide in Apple’s directory) | 'no'


### PR DESCRIPTION
- Adds some explainers to some confusing tags (ie. what is "block")
- Adds GUID (unique ID), this is optional for Apple Podcasts, which uses enclosure ID as fallback. However this is **mandatory** for Spotify.
- Adds episode art (will fallback to podcast art)
- Changes description from XML to CDATA. This allows using HTML tags like links.